### PR TITLE
4 Added `hv_control_logic.c/h` 

### DIFF
--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -3,18 +3,12 @@
 
 #include <stdbool.h>
 
-#define V_BAT_MIN 268.8
-#define V_BAT_MAX 400.0
-
-
 static void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_measure(HvcContext *context, HvcInputs  *in, HvcOutputs *out);
 static void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out);
-
-
 
 void hvc_init(HvcContext *context, uint32_t now_ms) {
     context->state = HVC_S_INIT;

--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -186,4 +186,10 @@ static void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = false;
     out->air_p_on = false;
     out->pc_on    = false;
+
+    if (in->command == HVC_CMD_CLEAR_FAULT) {
+        context->state = HVC_S_STANDBY;
+        return;
+    }
+
 }

--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -58,7 +58,15 @@ void hvc_update(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     return;
 }
 
-void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+static inline void hvc_bail_out(HvcContext *context, HvcOutputs *out, HvcState_t next_state) {
+    // Immediately force safe outputs
+    out->air_n_on = false;
+    out->air_p_on = false;
+    out->pc_on    = false;
+
+    context->state = next_state;
+}
+static void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = false;
     out->pc_on = false;
     out->air_p_on = false;
@@ -67,7 +75,7 @@ void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     context->state = HVC_S_STANDBY;
 }       
 
-void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+static void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = false;
     out->air_p_on = false;
     out->pc_on    = false;
@@ -80,13 +88,13 @@ void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
 }
 
 // We must close AIR_N, in order to measure the battery voltage
-void hvc_s_measure(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+static void hvc_s_measure(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = true;
     out->air_p_on = false;
     out->pc_on    = false;
 
     if (in->command != HVC_CMD_ENABLE_TS) {
-        context->state = HVC_S_STANDBY; // bail out safely
+        hvc_bail_out(context, out, HVC_S_STANDBY);
         return;
     }
  
@@ -99,36 +107,35 @@ void hvc_s_measure(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
 
     if (dt >= PC_MEASURE_TIMEOUT_MS) {
         context->fault = HVC_FAULT_MEASURE_TIMEOUT;
-        context->state = HVC_S_FAULT;
+        hvc_bail_out(context, out, HVC_S_FAULT);
         return;
     }
 
     if (in->battery_v < V_BAT_MIN) {
         context->fault = HVC_FAULT_UNDER_VOLT;
-        context->state = HVC_S_FAULT;
+        hvc_bail_out(context, out, HVC_S_FAULT);
         return;
     }
 
     if (in->battery_v > V_BAT_MAX) {
         context->fault = HVC_FAULT_OVER_VOLT;
-        context->state = HVC_S_FAULT;
+        hvc_bail_out(context, out, HVC_S_FAULT);
         return;
     }
 
     // we should now have a stable voltage reading
-
     context->start_tick_ms = in->now_ms;    // store time for timeout checks
     context->state = HVC_S_PC_ACTIVE;
 }
 
 // Now we are precharging!
-void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+static void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = true;
     out->air_p_on = false;
     out->pc_on    = true;
 
     if (in->command != HVC_CMD_ENABLE_TS) {
-        context->state = HVC_S_STANDBY; // bail out safely
+        hvc_bail_out(context, out, HVC_S_STANDBY);
         return;
     }
 
@@ -137,16 +144,15 @@ void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     // often caused by a missing precharge resistor
     if (dt >= PRECHARGE_MAX_TIME) {
         context->fault = HVC_FAULT_PC_TIMEOUT;
-        context->state = HVC_S_FAULT;
+        hvc_bail_out(context, out, HVC_S_FAULT);
         return;
     }
 
-    // todo: add hysteresis checks
     if (in->tractive_v >= PC_THRESH * in->battery_v) {
         // something is wrong if we precharge *too* fast.
         if(dt <= PC_MINTIME_MS) {
             context->fault = HVC_FAULT_PC_TO_FAST;
-            context->state = HVC_S_FAULT;
+            hvc_bail_out(context, out, HVC_S_FAULT);
             return;
         }
         // its alive!
@@ -157,13 +163,13 @@ void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     }
 }
 
-void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+static void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = true;
     out->air_p_on = true;
     out->pc_on    = false;
 
     if (in->command != HVC_CMD_ENABLE_TS) {
-        context->state = HVC_S_STANDBY; // bail out safely
+        hvc_bail_out(context, out, HVC_S_STANDBY);
         return;
     }
 
@@ -176,7 +182,7 @@ void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     }
 }
 
-void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+static void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = false;
     out->air_p_on = false;
     out->pc_on    = false;

--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -190,6 +190,7 @@ static void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->pc_on    = false;
 
     if (in->command == HVC_CMD_CLEAR_FAULT) {
+        context->fault = HVC_FAULT_CLEAR;
         context->state = HVC_S_STANDBY;
         return;
     }

--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -6,16 +6,13 @@
 #define V_BAT_MIN 268.8
 #define V_BAT_MAX 400.0
 
-#define TS_PC_TIMEOUT_MS 10000
-#define TS_SETTLE_MS 50
-#define TS_MEASURE_TIMEOUT_MS 500
 
-void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out);
-void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out);
-void hvc_s_measure(HvcContext *context, HvcInputs  *in, HvcOutputs *out);
-void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out);
-void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out);
-void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out);
+static void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out);
+static void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out);
+static void hvc_s_measure(HvcContext *context, HvcInputs  *in, HvcOutputs *out);
+static void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out);
+static void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out);
+static void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 
 
 
@@ -96,7 +93,13 @@ void hvc_s_measure(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     uint32_t dt = in->now_ms - context->start_tick_ms;
  
     // wait of TS voltage to settle
-    if (dt > TS_SETTLE_MS) {
+    if (dt < PC_SETTLE_MS) {
+        return;
+    }
+
+    if (dt >= PC_MEASURE_TIMEOUT_MS) {
+        context->fault = HVC_FAULT_MEASURE_TIMEOUT;
+        context->state = HVC_S_FAULT;
         return;
     }
 
@@ -132,15 +135,16 @@ void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     uint32_t dt = in->now_ms - context->start_tick_ms;
 
     // often caused by a missing precharge resistor
-    if (dt > PRECHARGE_MAX_TIME) {
+    if (dt >= PRECHARGE_MAX_TIME) {
         context->fault = HVC_FAULT_PC_TIMEOUT;
         context->state = HVC_S_FAULT;
         return;
     }
 
+    // todo: add hysteresis checks
     if (in->tractive_v >= PC_THRESH * in->battery_v) {
         // something is wrong if we precharge *too* fast.
-        if(dt < PC_MINTIME_MS) {
+        if(dt <= PC_MINTIME_MS) {
             context->fault = HVC_FAULT_PC_TO_FAST;
             context->state = HVC_S_FAULT;
             return;
@@ -166,7 +170,7 @@ void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     uint32_t dt = in->now_ms - context->start_tick_ms;
  
     // max 100ms of overlap allowed
-    // this helps settle the voltage
+    // this helps avoid any gap
     if (dt < PC_OVERLAP_MS) {
         out->pc_on = true;
     }

--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -1,7 +1,18 @@
 #include "hv_control_logic.h"
+#include "hvc_config.h"
+
+#include <stdbool.h>
+
+#define V_BAT_MIN 268.8
+#define V_BAT_MAX 400.0
+
+#define TS_PC_TIMEOUT_MS 10000
+#define TS_SETTLE_MS 50
+#define TS_MEASURE_TIMEOUT_MS 500
 
 void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out);
+void hvc_s_measure(HvcContext *context, HvcInputs  *in, HvcOutputs *out);
 void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out);
@@ -17,13 +28,23 @@ void hvc_init(HvcContext *context, uint32_t now_ms) {
 
 // Main HVC state machine update function
 void hvc_update(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-    
+
+    // state functions will enable required outputs each tick
+    out->air_n_on = false;
+    out->air_p_on = false;
+    out->pc_on    = false;
+
+    //todo: for all states, check BMS, IMD, SDC, etc.
+
     switch (context->state) {
         case HVC_S_INIT:
             hvc_s_init(context, in, out);
             break;
         case HVC_S_STANDBY:
             hvc_s_standby(context, in, out);
+            break;
+        case HVC_S_TS_MEASURE:
+           hvc_s_measure(context, in, out);
             break;
         case HVC_S_PC_ACTIVE:
             hvc_s_pc_active(context, in, out);
@@ -41,7 +62,6 @@ void hvc_update(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
 }
 
 void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-    // In INIT state, ensure all outputs are off
     out->air_n_on = false;
     out->pc_on = false;
     out->air_p_on = false;
@@ -51,17 +71,109 @@ void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
 }       
 
 void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-    return;
+    out->air_n_on = false;
+    out->air_p_on = false;
+    out->pc_on    = false;
+
+    if (in->command == HVC_CMD_ENABLE_TS) {
+        out->air_n_on = true;                   // close AIR_N to read TS voltage
+        context->start_tick_ms = in->now_ms;    // store time for timeout checks
+        context->state = HVC_S_TS_MEASURE;      // proceede
+    }
 }
 
+// We must close AIR_N, in order to measure the battery voltage
+void hvc_s_measure(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+    out->air_n_on = true;
+    out->air_p_on = false;
+    out->pc_on    = false;
+
+    if (in->command != HVC_CMD_ENABLE_TS) {
+        context->state = HVC_S_STANDBY; // bail out safely
+        return;
+    }
+ 
+    uint32_t dt = in->now_ms - context->start_tick_ms;
+ 
+    // wait of TS voltage to settle
+    if (dt > TS_SETTLE_MS) {
+        return;
+    }
+
+    if (in->battery_v < V_BAT_MIN) {
+        context->fault = HVC_FAULT_UNDER_VOLT;
+        context->state = HVC_S_FAULT;
+        return;
+    }
+
+    if (in->battery_v > V_BAT_MAX) {
+        context->fault = HVC_FAULT_OVER_VOLT;
+        context->state = HVC_S_FAULT;
+        return;
+    }
+
+    // we should now have a stable voltage reading
+
+    context->start_tick_ms = in->now_ms;    // store time for timeout checks
+    context->state = HVC_S_PC_ACTIVE;
+}
+
+// Now we are precharging!
 void hvc_s_pc_active(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-    return;
+    out->air_n_on = true;
+    out->air_p_on = false;
+    out->pc_on    = true;
+
+    if (in->command != HVC_CMD_ENABLE_TS) {
+        context->state = HVC_S_STANDBY; // bail out safely
+        return;
+    }
+
+    uint32_t dt = in->now_ms - context->start_tick_ms;
+
+    // often caused by a missing precharge resistor
+    if (dt > PRECHARGE_MAX_TIME) {
+        context->fault = HVC_FAULT_PC_TIMEOUT;
+        context->state = HVC_S_FAULT;
+        return;
+    }
+
+    if (in->tractive_v >= PC_THRESH * in->battery_v) {
+        // something is wrong if we precharge *too* fast.
+        if(dt < PC_MINTIME_MS) {
+            context->fault = HVC_FAULT_PC_TO_FAST;
+            context->state = HVC_S_FAULT;
+            return;
+        }
+        // its alive!
+        else {
+            context->start_tick_ms = in->now_ms;
+            context->state = HVC_S_TS_ENERGIZED;
+        }
+    }
 }
 
 void hvc_s_ts_energized(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-    return;
+    out->air_n_on = true;
+    out->air_p_on = true;
+    out->pc_on    = false;
+
+    if (in->command != HVC_CMD_ENABLE_TS) {
+        context->state = HVC_S_STANDBY; // bail out safely
+        return;
+    }
+
+    uint32_t dt = in->now_ms - context->start_tick_ms;
+ 
+    // max 100ms of overlap allowed
+    // this helps settle the voltage
+    if (dt < PC_OVERLAP_MS) {
+        out->pc_on = true;
+    }
 }
 
 void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-    return;
+    out->air_n_on = false;
+    out->air_p_on = false;
+    out->pc_on    = false;
 }

--- a/Core/User/hv_control_logic.c
+++ b/Core/User/hv_control_logic.c
@@ -1,8 +1,10 @@
 #include "hv_control_logic.h"
+#include "hv_control.h"
 #include "hvc_config.h"
 
 #include <stdbool.h>
 
+static bool check_sdc(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out);
 static void hvc_s_measure(HvcContext *context, HvcInputs  *in, HvcOutputs *out);
@@ -19,14 +21,18 @@ void hvc_init(HvcContext *context, uint32_t now_ms) {
 
 // Main HVC state machine update function
 void hvc_update(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
-
     // state functions will enable required outputs each tick
     out->air_n_on = false;
     out->air_p_on = false;
     out->pc_on    = false;
 
-    //todo: for all states, check BMS, IMD, SDC, etc.
+    // SDC may open at any time, for many reasons
+    // we can recover if the SDC signal returns
+    if (!check_sdc(context, in, out)) {
+        return;
+    }
 
+    // HVC State Machine
     switch (context->state) {
         case HVC_S_INIT:
             hvc_s_init(context, in, out);
@@ -49,7 +55,6 @@ void hvc_update(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
         default:
             context->state = HVC_S_FAULT;
     }
-    return;
 }
 
 static inline void hvc_bail_out(HvcContext *context, HvcOutputs *out, HvcState_t next_state) {
@@ -60,6 +65,8 @@ static inline void hvc_bail_out(HvcContext *context, HvcOutputs *out, HvcState_t
 
     context->state = next_state;
 }
+
+// Entry state
 static void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = false;
     out->pc_on = false;
@@ -67,8 +74,9 @@ static void hvc_s_init(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
 
     // Transition to STANDBY after initialization
     context->state = HVC_S_STANDBY;
-}       
+}
 
+// SDC is present, but we are waiting for the PC command.
 static void hvc_s_standby(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     out->air_n_on = false;
     out->air_p_on = false;
@@ -187,3 +195,20 @@ static void hvc_s_fault(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
     }
 
 }
+
+static bool check_sdc(HvcContext *context, HvcInputs *in, HvcOutputs *out) {
+    if (in->sdc_ok) {
+        return true;
+    }
+
+    // SDC is open, force safe outputs
+    out->air_n_on = false;
+    out->air_p_on = false;
+    out->pc_on    = false;
+
+    // we can recover from a SDC fault, so return to standby
+    context->fault = HVC_FAULT_SDC_LOST;
+    context->state = HVC_S_STANDBY;
+    return false;
+}
+

--- a/Core/User/hv_control_logic.h
+++ b/Core/User/hv_control_logic.h
@@ -19,6 +19,7 @@ typedef enum {
     HVC_FAULT_OVER_VOLT,
     HVC_FAULT_UNDER_VOLT,
     HVC_FAULT_MEASURE_TIMEOUT,
+    HVC_FAULT_SDC_LOST,
 } HvcFaultCode_t;
 
 typedef enum {

--- a/Core/User/hv_control_logic.h
+++ b/Core/User/hv_control_logic.h
@@ -17,7 +17,8 @@ typedef enum {
     HVC_FAULT_PC_TIMEOUT,
     HVC_FAULT_PC_TO_FAST,
     HVC_FAULT_OVER_VOLT,
-    HVC_FAULT_UNDER_VOLT
+    HVC_FAULT_UNDER_VOLT,
+    HVC_FAULT_MEASURE_TIMEOUT,
 } HvcFaultCode_t;
 
 typedef enum {

--- a/Core/User/hv_control_logic.h
+++ b/Core/User/hv_control_logic.h
@@ -6,9 +6,10 @@
 typedef enum {
     HVC_S_INIT                = 0x00U,
     HVC_S_STANDBY             = 0x01U,
-    HVC_S_PC_ACTIVE           = 0x02U,
-    HVC_S_TS_ENERGIZED        = 0x03U,
-    HVC_S_FAULT           = 0x04U,
+    HVC_S_TS_MEASURE          = 0x02U,
+    HVC_S_PC_ACTIVE           = 0x03U,
+    HVC_S_TS_ENERGIZED        = 0x04U,
+    HVC_S_FAULT               = 0x05U,
 } HvcState_t;
 
 typedef enum {
@@ -20,16 +21,16 @@ typedef enum {
 } HvcFaultCode_t;
 
 typedef enum {
-    ENABLE_TS = 0,
-    DISABLE_TS,
-    CLEAR_FAULT,
+    HVC_CMD_ENABLE_TS = 0,
+    HVC_CMD_DISABLE_TS,
+    HVC_CMD_CLEAR_FAULT,
 } HvcCmd_t;
 
 // Used to control PC state machine
 typedef struct {
     HvcCmd_t command; 
 
-    float pack_v;
+    float tractive_v;
     float battery_v;
 
     bool imd_ok;
@@ -61,11 +62,11 @@ static inline HvcInputs _hvc_inputs_default(void)
 {
     HvcInputs in = {0};
 
-    in.command = DISABLE_TS;
+    in.command = HVC_CMD_DISABLE_TS;
     in.imd_ok = false;
     in.bms_ok = false;
     in.sdc_ok = false;
-    in.pack_v = 0.0f;
+    in.tractive_v = 0.0f;
     in.battery_v = 0.0f;
     in.now_ms = 0;
 

--- a/Core/User/hvc_config.h
+++ b/Core/User/hvc_config.h
@@ -19,12 +19,14 @@
 
 // PRECHARGE SETTINGS
 
-#define SDC_ADC_MIN_VOLTAGE 128
-#define SIMPLE_PC_LENGTH_MS 5000
-#define PC_TIMEOUT_MS       10000       // Throw a fault if PC is longer than value (ms)
-#define PC_MINTIME_MS       100         // Throw a fault if PC is shorter than value (ms)    
-#define PC_OVERLAP_MS       10          // Allow AIR_N and the PC relay to both be on for (ms)
-#define PC_THRESH           0.90f       // Bring TS to % of the pack voltage
+#define SDC_ADC_MIN_VOLTAGE     128
+#define SIMPLE_PC_LENGTH_MS     5000
+#define PC_TIMEOUT_MS           10000       // Throw a fault if PC is longer than value (ms)
+#define PC_MINTIME_MS           100         // Throw a fault if PC is shorter than value (ms)    
+#define PC_OVERLAP_MS           10          // Allow AIR_N and the PC relay to both be on for (ms)
+#define PC_THRESH               0.90f       // Bring TS to % of the pack voltage
+#define PC_SETTLE_MS            50
+#define PC_MEASURE_TIMEOUT_MS   500
 
 #endif
 

--- a/Core/User/hvc_config.h
+++ b/Core/User/hvc_config.h
@@ -21,8 +21,10 @@
 
 #define SDC_ADC_MIN_VOLTAGE 128
 #define SIMPLE_PC_LENGTH_MS 5000
-#define PC_TIMEOUT_MS 10000     // Throw a fault if PC is longer than value (ms)
-#define PC_MINTIME_MS 100       // Throw a fault if PC is shorter than value (ms)    
-#define PC_THRESH 0.90f         // Bring TS to 95% of the pack voltage
+#define PC_TIMEOUT_MS       10000       // Throw a fault if PC is longer than value (ms)
+#define PC_MINTIME_MS       100         // Throw a fault if PC is shorter than value (ms)    
+#define PC_OVERLAP_MS       10          // Allow AIR_N and the PC relay to both be on for (ms)
+#define PC_THRESH           0.90f       // Bring TS to % of the pack voltage
 
 #endif
+

--- a/Core/User/hvc_config.h
+++ b/Core/User/hvc_config.h
@@ -28,5 +28,10 @@
 #define PC_SETTLE_MS            50
 #define PC_MEASURE_TIMEOUT_MS   500
 
+// BATTERY SEETINGS
+
+#define V_BAT_MIN 268.8
+#define V_BAT_MAX 400.0
+
 #endif
 


### PR DESCRIPTION
# Summary

Closes #4 
Closes #31 

Refactors the HVC state machine to improve safety and readability.

## System Design and Justification

The previous HVC state machine logic was closely tied to the hardware calls. This meant that testing *had* to be done on real hardware, with a mock tractive system setup. See #5 for how I tested the original code.

This design does *not* rely on any SMT32 systems; instead, it uses a finite-state machine that contains all the logic. The actual hardware calls will be implemented in `hv_control.c/h`

The HVC operates as a finite state machine with explicit states for initialization, standby, TS voltage measurement, precharge, energized, and fault. 

The code is tick-driven, which means there are no blocking delays. This should allow the code to work with or without a scheduler (i.e. FreeRTOS). 

This is an active precharge sequence, which means the voltage is monitored, and must be within a minimum threshold before closing both contractors. This allows extra safety checks (ex. `PC_TIMEOUT`)

## How to Use

This design uses structs to separate:

- Inputs (commands, voltages, safety interlocks, time)
- Outputs (AIRs and precharge control)
- Context (state, fault code, timing)

The application will pass these objects, and call a tick function. The output will be used to control relays, and handle faults. Context is used to manage internal states, but could also be used for datalogging.

## Todo

- [ ] Add BMS, IMD, SDC checks
- [ ] Add full suite of unit test 
- [ ] Test on actual hardware
